### PR TITLE
Add sd_check function to pyportal

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -661,6 +661,13 @@ class PyPortal:
         return IMAGE_CONVERTER_SERVICE % (aio_username, aio_key,
                                           width, height,
                                           color_depth, image_url)
+    def sd_check(self):
+        """Returns True if there is an SD card preset and False
+        if there is no SD card. The _sdcard value is set in _init
+        """
+        if self._sdcard:
+            return True
+        return False
 
     def fetch(self, refresh_url=None):
         """Fetch data from the url we initialized with, perfom any parsing,


### PR DESCRIPTION
Both __init__ and fetch access the in self._sdcard parameter to determine
if a SD card is installed. __init__ handles the mounting of the card.
fetch() alters the filename path as needed prior to calling wget(). This
new function will allow the calling of pyportal.sd_check() to determine
if a card is present and alter operations as needed.
Simple example:
if pyportal.sdcheck():
    print("SD card is installed")
else:
    print("SD card is NOT installed")