### PR TITLE
Patch Adafruit IO CircuitPython to match for latest breaking release

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -691,7 +691,7 @@ class PyPortal:
             raise KeyError("Adafruit IO secrets are kept in secrets.py, please add them there!\n\n")
 
         wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(self._esp, secrets, None)
-        io_client = RESTClient(aio_username, aio_key, wifi)
+        io_client = IO_HTTP(aio_username, aio_key, wifi)
 
         while True:
             try:

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -69,7 +69,7 @@ import audioio
 import rtc
 import supervisor
 
-from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
+from adafruit_io.adafruit_io import IO_HTTP, AdafruitIO_RequestError
 
 try:
     from secrets import secrets


### PR DESCRIPTION
Changing `RESTClient` -> `IO_HTTP` to match the breaking release of Adafruit IO CircuitPython:
https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/releases/tag/2.0.0