### PR TITLE
Update library for PyGamer/PyBadge

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -52,12 +52,13 @@ from digitalio import DigitalInOut
 import pulseio
 import neopixel
 
+from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
+import adafruit_esp32spi.adafruit_esp32spi_requests as requests
+
 import adafruit_touchscreen
 from adafruit_cursorcontrol.cursorcontrol import Cursor
 from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
 
-from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_requests as requests
 try:
     from adafruit_display_text.text_area import TextArea  # pylint: disable=unused-import
     print("*** WARNING ***\nPlease update your library bundle to the latest 'adafruit_display_text' version as we've deprecated 'text_area' in favor of 'label'")  # pylint: disable=line-too-long

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -50,8 +50,16 @@ import board
 import busio
 from digitalio import DigitalInOut
 import pulseio
-import adafruit_touchscreen
 import neopixel
+try:
+    import adafruit_touchscreen
+except ImportError:
+    pass
+try:
+    from adafruit_cursorcontrol.cursorcontrol import Cursor
+    from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
+except ImportError:
+    pass
 
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_requests as requests
@@ -164,6 +172,8 @@ class PyPortal:
         self._debug = debug
 
         try:
+            self._backlight = pulseio.PWMOut(board.TFT_LITE)  # pylint: disable=no-member
+        except AttributeError:
             self._backlight = pulseio.PWMOut(board.TFT_BACKLIGHT)  # pylint: disable=no-member
         except ValueError:
             self._backlight = None
@@ -224,7 +234,10 @@ class PyPortal:
 
         self._speaker_enable = DigitalInOut(board.SPEAKER_ENABLE)
         self._speaker_enable.switch_to_output(False)
-        self.audio = audioio.AudioOut(board.AUDIO_OUT)
+        try: # PyPortal
+            self.audio = audioio.AudioOut(board.AUDIO_OUT)
+        except AttributeError: # PyGamer/PyBadge
+            self.audio = audioio.AudioOut(board.SPEAKER)
         try:
             self.play_file("pyportal_startup.wav")
         except OSError:
@@ -347,18 +360,26 @@ class PyPortal:
                 self._image_position = (0, 0)  # default to top corner
             if not self._image_resize:
                 self._image_resize = (320, 240)  # default to full screen
+        if hasattr(board, 'TOUCH_XL'):
+            if self._debug:
+                print("Init touchscreen")
+            # pylint: disable=no-member
+            self.touchscreen = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
+                                                                board.TOUCH_YD, board.TOUCH_YU,
+                                                                calibration=((5200, 59000),
+                                                                             (5800, 57000)),
+                                                                size=(320, 240))
+            # pylint: enable=no-member
 
-        if self._debug:
-            print("Init touchscreen")
-        # pylint: disable=no-member
-        self.touchscreen = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
-                                                            board.TOUCH_YD, board.TOUCH_YU,
-                                                            calibration=((5200, 59000),
-                                                                         (5800, 57000)),
-                                                            size=(320, 240))
-        # pylint: enable=no-member
-
-        self.set_backlight(1.0)  # turn on backlight
+            self.set_backlight(1.0)  # turn on backlight
+        elif hasattr(board, 'BUTTON_CLOCK'):
+            if self._debug:
+                print("Init cursor")
+            self.mouse_cursor = Cursor(board.DISPLAY, display_group=self.splash, cursor_speed=8)
+            self.mouse_cursor.hide()
+            self.cursor = CursorManager(self.mouse_cursor)
+        else:
+            raise AttributeError('PyPortal module requires either a touchscreen or gamepad.')
 
         gc.collect()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extensions = [
 autodoc_mock_imports = ["rtc", "supervisor", "pulseio", "audioio", "displayio", "neopixel",
                         "microcontroller", "adafruit_touchscreen", "adafruit_bitmap_font",
                         "adafruit_display_text", "adafruit_esp32spi", "secrets",
-                        "adafruit_sdcard", "storage", "adafruit_io"]
+                        "adafruit_sdcard", "storage", "adafruit_io", "adafruit_cursorcontrol"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'BusDevice': ('https://circuitpython.readthedocs.io/projects/busdevice/en/latest/', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}


### PR DESCRIPTION
This pull request adds support for using this library with a PyGamer/PyBadge + FeatherWing (requires `esp` and `external_spi` objects to be passed into the `init` constructor).

In addition to adding pin-compatibility, it also creates a hidden cursor object (https://github.com/adafruit/Adafruit_CircuitPython_CursorControl) if the board used with PyPortal is a PyBadge/PyGamer to substitute for the PyPortal's touchscreen.