### PR TITLE
Fix TFT-in-use-error

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -167,11 +167,12 @@ class PyPortal:
 
         self._debug = debug
 
-        if hasattr(board, 'TFT_BACKLIGHT'):
-            self._backlight = pulseio.PWMOut(board.TFT_BACKLIGHT)  # pylint: disable=no-member
-        elif hasattr(board, 'TFT_LITE'):
-            self._backlight = pulseio.PWMOut(board.TFT_LITE)  # pylint: disable=no-member
-        else:
+        try:
+            if hasattr(board, 'TFT_BACKLIGHT'):
+                self._backlight = pulseio.PWMOut(board.TFT_BACKLIGHT)  # pylint: disable=no-member
+            elif hasattr(board, 'TFT_LITE'):
+                self._backlight = pulseio.PWMOut(board.TFT_LITE)  # pylint: disable=no-member
+        except ValueError:
             self._backlight = None
         self.set_backlight(1.0)  # turn on backlight
 


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/issues/48 on 4.1.0 RC1. Reverts to the try/except modified by https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/pull/45

Works with no errors (incl. importerrors) when combined with  https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/pull/47