### PR TITLE
Update to CircuitPython_Requests

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -52,7 +52,8 @@ from digitalio import DigitalInOut
 import pulseio
 import neopixel
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_requests as requests
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_requests as requests
 import storage
 import displayio
 import audioio
@@ -273,7 +274,7 @@ class PyPortal:
                 self._esp.reset()
         else:
             raise RuntimeError("Was not able to find ESP32")
-        requests.set_interface(self._esp)
+        requests.set_socket(socket, self._esp)
 
         if url and not self._uselocal:
             self._connect_esp()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,8 @@ extensions = [
 autodoc_mock_imports = ["rtc", "supervisor", "pulseio", "audioio", "displayio", "neopixel",
                         "microcontroller", "adafruit_touchscreen", "adafruit_bitmap_font",
                         "adafruit_display_text", "adafruit_esp32spi", "secrets",
-                        "adafruit_sdcard", "storage", "adafruit_io", "adafruit_cursorcontrol"]
+                        "adafruit_sdcard", "storage", "adafruit_io", "adafruit_cursorcontrol",
+                        "adafruit_requests"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'BusDevice': ('https://circuitpython.readthedocs.io/projects/busdevice/en/latest/', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}


### PR DESCRIPTION
This PR updates this library to use the CircuitPython_Requests module instead of ESP32SPI_Requests (req.s latest https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/61)

Tested on `Adafruit CircuitPython 4.1.0-rc.1 on 2019-07-19; Adafruit PyPortal`