### PR TITLE
Fixes to wget in the event of an HTTP error

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -635,7 +635,10 @@ class PyPortal:
 
         if self._debug:
             print(r.headers)
-        content_length = int(r.headers['content-length'])
+        if 'content-length' in r.headers:
+            content_length = int(r.headers['content-length'])
+        else:
+            raise RuntimeError("Invalid Header")
         remaining = content_length
         print("Saving data to ", filename)
         stamp = time.monotonic()


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/issues/51 :
Checks that the content-length is in r.headers prior to using it and raises a runtime exception if it is not present.