### PR TITLE
 remove call to wait_for_frame

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -550,7 +550,6 @@ class PyPortal:
         :param str file_name: The name of the wav file to play on the speaker.
 
         """
-        board.DISPLAY.wait_for_frame()
         wavfile = open(file_name, "rb")
         wavedata = audioio.WaveFile(wavfile)
         self._speaker_enable.value = True


### PR DESCRIPTION
fixes #53 
tested on pyportal under 4.1.0 and 5.x master -- works with and with or pyportal_startup.wav  file.
