### PR TITLE
Update fetch() for portrait oriented images

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -88,6 +88,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyPortal.git"
 
 # pylint: disable=line-too-long
+# pylint: disable=too-many-lines
 # you'll need to pass in an io username, width, height, format (bit depth), io key, and then url!
 IMAGE_CONVERTER_SERVICE = "https://io.adafruit.com/api/v2/%s/integrations/image-formatter?x-aio-key=%s&width=%d&height=%d&output=BMP%d&url=%s"
 # you'll need to pass in an io username and key

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -858,7 +858,7 @@ class PyPortal:
                 print("original URL:", image_url)
                 if iwidth < iheight:
                     image_url = self.image_converter_url(image_url,
-                                                         int(self._image_resize[1] 
+                                                         int(self._image_resize[1]
                                                              * self._image_resize[1]
                                                              / self._image_resize[0]),
                                                          self._image_resize[1])
@@ -883,13 +883,13 @@ class PyPortal:
                     print(error)
                     raise RuntimeError("wget didn't write a complete file")
                 if iwidth < iheight:
-                    pwidth = int(self._image_resize[1] * 
+                    pwidth = int(self._image_resize[1] *
                                  self._image_resize[1] / self._image_resize[0])
                     self.set_background(filename,
-                                        (self._image_position[0] 
-                                         + int((self._image_resize[0] 
+                                        (self._image_position[0]
+                                         + int((self._image_resize[0]
                                                 - pwidth) / 2),
-                                        self._image_position[1]))
+                                         self._image_position[1]))
                 else:
                     self.set_background(filename, self._image_position)
 

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -846,7 +846,7 @@ class PyPortal:
         if self._image_dim_json_path:
             iwidth = int(PyPortal._json_traverse(json_out, self._image_dim_json_path[0]))
             iheight = int(PyPortal._json_traverse(json_out, self._image_dim_json_path[1]))
-            print("image dim:",iwidth,iheight)
+            print("image dim:", iwidth, iheight)
 
         # we're done with the requests object, lets delete it so we can do more!
         json_out = None
@@ -858,7 +858,7 @@ class PyPortal:
                 print("original URL:", image_url)
                 if iwidth < iheight:
                     image_url = self.image_converter_url(image_url,
-                                                         int( self._image_resize[1] * self._image_resize[1]
+                                                         int(self._image_resize[1] * self._image_resize[1]
                                                              / self._image_resize[0]),
                                                          self._image_resize[1])
                 else:
@@ -882,7 +882,7 @@ class PyPortal:
                     print(error)
                     raise RuntimeError("wget didn't write a complete file")
                 if iwidth < iheight:
-                    pwidth = int( self._image_resize[1] * self._image_resize[1] / self._image_resize[0])
+                    pwidth = int(self._image_resize[1] * self._image_resize[1] / self._image_resize[0])
                     self.set_background(filename, (self._image_position[0] + int((self._image_resize[0] - pwidth) / 2),
                                         self._image_position[1]))
                 else:

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -858,7 +858,8 @@ class PyPortal:
                 print("original URL:", image_url)
                 if iwidth < iheight:
                     image_url = self.image_converter_url(image_url,
-                                                         int(self._image_resize[1] * self._image_resize[1]
+                                                         int(self._image_resize[1] 
+                                                             * self._image_resize[1]
                                                              / self._image_resize[0]),
                                                          self._image_resize[1])
                 else:
@@ -882,8 +883,12 @@ class PyPortal:
                     print(error)
                     raise RuntimeError("wget didn't write a complete file")
                 if iwidth < iheight:
-                    pwidth = int(self._image_resize[1] * self._image_resize[1] / self._image_resize[0])
-                    self.set_background(filename, (self._image_position[0] + int((self._image_resize[0] - pwidth) / 2),
+                    pwidth = int(self._image_resize[1] * 
+                                 self._image_resize[1] / self._image_resize[0])
+                    self.set_background(filename,
+                                        (self._image_position[0] 
+                                         + int((self._image_resize[0] 
+                                                - pwidth) / 2),
                                         self._image_position[1]))
                 else:
                     self.set_background(filename, self._image_position)


### PR DESCRIPTION
This code was added to allow multiple fetch() commands to work correctly when there is a mix of portrait and landscape oriented images to display on the PyPortal. An additional parameter, image_dim_json_path, was added to init() to point to the JSON section that contains the original width and height of the image. If this parameter (a width and height tuple) is not present, the fetch should work as before with no portrait mode considerations.

Here is an example of the feature being used. I commented out some of the lines so the code could run without external file dependencies. Specific landscape and portrait itemids can be uncommented  for testing, or use the randomint() function.

More info on the api used in the example is here: https://openaccess-api.clevelandart.org/

```
import time
import board
import random
from adafruit_pyportal import PyPortal
from adafruit_display_shapes.circle import Circle

WIDTH = board.DISPLAY.width
HEIGHT = board.DISPLAY.height

apiurl = "https://openaccess-api.clevelandart.org/api/artworks?cc0=1&has_image=1&indent=2&limit=1&skip="

pyportal = PyPortal(
                    # default_bg=background_file,
                    image_json_path=["data",0,"images","web","url"],
                    image_dim_json_path=(["data",0,"images","web","width"],["data",0,"images","web","height"]),
                    image_resize=(WIDTH, HEIGHT - 15),
                    image_position=(0, 0),
                    #text_font="/fonts/OpenSans-9.bdf",
                    #json_path=["data",0,"title"],
                    #text_position=(4,HEIGHT - 9),
                    #text_color =0xFFFFFF
                    )

circle = Circle(312, 233, 5, fill=0)
pyportal.splash.append(circle)
loopcount = 0
errorcount = 0
while True:
    response = None
    try:
        circle.fill = 0xFF0000
        itemid = random.randint(1, 30000)
        # itemid = 20 # portrait mode example
        # itemid = 21 # landscape mode example
        print("retrieving url:", apiurl +str(itemid))
        response = pyportal.fetch(apiurl + str(itemid))
        circle.fill = 0
        print("Response is", response)
        loopcount = loopcount + 1

    except (RuntimeError, KeyError) as e:
        print("An error occured, retrying! -", e)
        print("loop counter:", loopcount)
        assert errorcount < 20, "Too many errors, stopping"
        errorcount = errorcount + 1
        continue

    errorcount = 0
    stamp = time.monotonic()
    # wait 5 minutes before getting again
    while (time.monotonic() - stamp) < (5*60):
        # or, if they touch the screen, fetch immediately!
        if pyportal.touchscreen.touch_point:
            break

```