### PR TITLE
Check the response status code before parsing time, raise more verbose error

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -620,6 +620,8 @@ class PyPortal:
         api_url += TIME_SERVICE_STRFTIME
         try:
             response = requests.get(api_url)
+            if response.status_code != 200:
+                raise ValueError(response.text)
             if self._debug:
                 print("Time request: ", api_url)
                 print("Time reply: ", response.text)


### PR DESCRIPTION
Addressing: https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/issues/57

Previous error with invalid Adafruit IO Account:
```
Traceback (most recent call last):
  File "code.py", line 44, in <module>
  File "adafruit_pyportal.py", line 629, in get_local_time
  File "adafruit_pyportal.py", line 625, in get_local_time
ValueError: invalid syntax for integer with base 10 
```

New code check status code. Error text pulled from response's text:
```
Traceback (most recent call last):
  File "code.py", line 25, in <module>
  File "/lib/adafruit_pyportal.py", line 635, in get_local_time
  File "/lib/adafruit_pyportal.py", line 624, in get_local_time
ValueError: {"error":"not found - that username does not exist"}
```

Correct operation (status code 200 OK):
```
Getting time for timezone America/New_York
Time request:  https://io.adafruit.com/api/v2/USERNAME/integrations/time/strftime?x-aio-key=aio_idOM89t6ejKZ03uzX5cU1taV3Sxv&tz=America/New_York&fmt=%25Y-%25m-%25d+%25H%3A%25M%3A%25S.%25L+%25j+%25u+%25z+%25Z
Time reply:  2020-01-28 11:38:00.983 028 2 -0500 EST
struct_time(tm_year=2020, tm_mon=1, tm_mday=28, tm_hour=11, tm_min=38, tm_sec=0, tm_wday=2, tm_yday=28, tm_isdst=None)
```