### PR TITLE
Reduced chunk_size to reduce memory fragmentation

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -873,7 +873,7 @@ class PyPortal:
                 # convert image to bitmap and cache
                 #print("**not actually wgetting**")
                 filename = "/cache.bmp"
-                chunk_size = 12000      # default chunk size is 12K (for QSPI)
+                chunk_size = 4096      # default chunk size is 12K (for QSPI)
                 if self._sdcard:
                     filename = "/sd" + filename
                     chunk_size = 512  # current bug in big SD writes -> stick to 1 block


### PR DESCRIPTION
Running a PyPortal Titano on CP 5.0.0-beta.4, I was getting MemoryError exceptions after 10 to 20 fetch() calls within a loop. Further research showed the memory was not low, but apparently fragmented. I added some gc.collect() calls in different functions, but that did not help. Finally, I reduced the chunk_size value from 12000 to 4096. This helped greatly, and I was able to get over 300 fetch loops (and counting) without the exception. I suggest implementing this solution until a better solution is found to address memory fragmentation with a higher higher chunk_size value.

The code used to test this issue is here:

https://github.com/adafruit/Adafruit_Learning_System_Guides/tree/master/PyPortal_CMA_Art_Frame

You can reduce the while loop wait to 60 seconds to help speed up the looping for testing.