### PR TITLE
Fixed typo "adafruit-circuitpython-bitmap-font"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "adafruit-circuitpython-busdevice",
         "adafruit-circuitpython-touchscreen",
         "adafruit-circuitpython-esp32spi",
-        "adafruit-circuitpython-bitmapfont",
+        "adafruit-circuitpython-bitmap-font",
         "adafruit-circuitpython-displaytext",
         "adafruit-circuitpython-neopixel",
     ],


### PR DESCRIPTION
I tried installing adafruit-circuitpython-pyportal, but it failed because it couldn't find "adafruit-circuitpython-bitmapfont," which doesn't exist.

The correct library name is "adafruit-circuitpython-bitmap-font"