### PR TITLE
Fixed typo in "adafruit-circuitpython-display-text"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "adafruit-circuitpython-touchscreen",
         "adafruit-circuitpython-esp32spi",
         "adafruit-circuitpython-bitmap-font",
-        "adafruit-circuitpython-displaytext",
+        "adafruit-circuitpython-display-text",
         "adafruit-circuitpython-neopixel",
     ],
     # Choose your license


### PR DESCRIPTION
Looks like there were typos in two packages!

I've verified that it installs successfully with this second typo fix.