### PR TITLE
Raise error on HTTP Error and fix json w/ no path

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -938,9 +938,6 @@ class PyPortal:
                     elif "application/javascript" in headers["content-type"]:
                         content_type = CONTENT_JSON
             else:
-                print(
-                    "HTTP Error {}: {}".format(r.status_code, r.reason.decode("utf-8"))
-                )
                 if self._debug:
                     if "content-length" in headers:
                         print(
@@ -949,7 +946,9 @@ class PyPortal:
                     if "date" in headers:
                         print("Date: {}".format(headers["date"]))
                 self.neo_status((100, 0, 0))  # red = http error
-                return None
+                raise OSError(
+                    "HTTP {}: {}".format(r.status_code, r.reason.decode("utf-8"))
+                )
 
         if self._debug and content_type == CONTENT_TEXT:
             print(r.text)
@@ -993,11 +992,17 @@ class PyPortal:
                 except KeyError:
                     print(json_out)
                     raise
-        elif self._regexp_path:
+        elif content_type == CONTENT_TEXT and self._regexp_path:
             for regexp in self._regexp_path:
                 values.append(re.search(regexp, r.text).group(1))
         else:
-            values = r.text
+            if content_type == CONTENT_JSON:
+                # No path given, so return JSON as string for compatibility
+                import json  # pylint: disable=import-outside-toplevel
+
+                values = json.dumps(r.json())
+            else:
+                values = r.text
 
         if self._image_json_path:
             try:


### PR DESCRIPTION
Fixes #92. I also am raising an error for HTTP errors. The reason for this is it was returning None and later in the code giving an unrelated confusing message.

The bulk of this PR is if no Path is defined, values was an empty list and code that was written such as the weather station expected the JSON as a string to be returned. I realize loading json and using json.dumps() uses more memory, but rather than only grabbing r.text if there was no path, I didn't want to break it if the json_transform was provided which expects a dict. However, it won't load json until it actually has to so it only does it for the single edge case.