### PR TITLE
get_local_time is expected to raise RuntimeError when it fails

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -722,7 +722,7 @@ class PyPortal:
         try:
             response = requests.get(api_url, timeout=10)
             if response.status_code != 200:
-                raise ValueError(response.text)
+                raise RuntimeError(response.text)
             if self._debug:
                 print("Time request: ", api_url)
                 print("Time reply: ", response.text)


### PR DESCRIPTION
When response.status_code != 200 from the REST api to TIME_SERVICE
the code raises ValueError, which is not what all the examples in
Adafruit_Learning_System_Guides handle gracefully. Instead, this
situation should be raising the RuntimeError exception.

Fixes https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/issues/96 .