### PR TITLE
Added missing value extractor

### DIFF
--- a/adafruit_pyportal/__init__.py
+++ b/adafruit_pyportal/__init__.py
@@ -357,4 +357,7 @@ class PyPortal(PortalBase):
         response = None
         gc.collect()
 
+        if len(values) == 1:
+            values = values[0]
+
         return values


### PR DESCRIPTION
The Tide Viewer code was failing because it was not properly having the values extracted. Tested with Tides Viewer and Open Weather demos.