### PR TITLE
fix api.rst to include all modules

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,15 @@
 
 .. automodule:: adafruit_pyportal
    :members:
+
+.. automodule:: adafruit_pyportal.graphics
+   :members:
+
+.. automodule:: adafruit_pyportal.network
+   :members:
+
+.. automodule:: adafruit_pyportal.peripherals
+   :members:
+
+.. automodule:: adafruit_pyportal.wifi
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,18 +26,27 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = [
+    "busio",
+    "board",
+    "digitalio",
     "rtc",
     "supervisor",
     "pulseio",
+    "pwmio",
     "audioio",
     "audiocore",
     "microcontroller",
+    "neopixel",
     "secrets",
     "adafruit_sdcard",
     "storage",
     "sdcardio",
+    "terminalio",
     "adafruit_io",
     "adafruit_cursorcontrol",
+    "adafruit_esp32spi",
+    "adafruit_requests",
+    "adafruit_portalbase",
 ]
 
 


### PR DESCRIPTION
Add the missing modules to api.rst

- adafruit_pyportal.graphics
- adafruit_pyportal.network
- adafruit_pyportal.peripherals
- adafruit_pyportal.wifi