### PR TITLE
Added headers parameter to network.fetch call

### DIFF
--- a/adafruit_pyportal/__init__.py
+++ b/adafruit_pyportal/__init__.py
@@ -303,7 +303,7 @@ class PyPortal(PortalBase):
         if refresh_url:
             self.url = refresh_url
 
-        response = self.network.fetch(self.url, timeout=timeout)
+        response = self.network.fetch(self.url, headers=self._headers, timeout=timeout)
 
         json_out = None
         content_type = self.network.check_response(response)


### PR DESCRIPTION
The header parameter was not being passed to the network.fetch call.  This broke any request that required a authentication header to retrieve data  (i.e. Twitter)

I added headers=self._headers to the network.fetch call and tested with the Twitter API.