### PR TITLE
Assign requests if we have already connected

### DIFF
--- a/adafruit_pyportal/wifi.py
+++ b/adafruit_pyportal/wifi.py
@@ -74,6 +74,8 @@ class WiFi:
             )
 
         requests.set_socket(socket, self.esp)
+        if esp.is_connected:
+            self.requests = requests
         self._manager = None
 
         gc.collect()


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/issues/24. The issue is that requests was only assigned once we called connect, but if we were already connected, requests was never assigned.