### PR TITLE
Adding examples, changing API index, examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,21 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/pyportal_simpletest.py
     :caption: examples/pyportal_simpletest.py
     :linenos:
+
+Internet test
+-------------
+
+Example to illustrate the device capability to get json data
+
+.. literalinclude:: ../examples/pyportal_internet_json_fetching.py
+    :caption: examples/pyportal_internet_json_fetching.py
+    :linenos:
+
+QR Test
+-------
+
+This example shows a web address QR in the display
+
+.. literalinclude:: ../examples/pyportal_qrcode_generation.py
+    :caption: examples/pyportal_qrcode_generation.py
+    :linenos:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ Table of Contents
 .. toctree::
     :caption: Tutorials
 
+    Adafruit PyPortal Learning Guide <https://learn.adafruit.com/adafruit-pyportal>
+
 .. toctree::
     :caption: Related Products
 

--- a/examples/pyportal_internet_json_fetching.py
+++ b/examples/pyportal_internet_json_fetching.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+Example to illustrate the device capability to get json data
+"""
+
+# NOTE: Make sure you've created your secrets.py file before running this example
+# https://learn.adafruit.com/adafruit-pyportal/internet-connect#whats-a-secrets-file-17-2
+import board
+from digitalio import DigitalInOut
+import adafruit_requests as requests
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+from adafruit_esp32spi import adafruit_esp32spi
+
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+print("ESP32 SPI webclient test")
+
+TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
+JSON_URL = "http://api.coindesk.com/v1/bpi/currentprice/USD.json"
+
+
+# ESP32 Pins:
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+
+# SPI Configuration
+spi = board.SPI()
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+requests.set_socket(socket, esp)
+
+if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
+    print("ESP32 found and in idle mode")
+print("Firmware vers.", esp.firmware_version)
+print("MAC addr:", [hex(i) for i in esp.MAC_address])
+
+for ap in esp.scan_networks():
+    print("\t%s\t\tRSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
+
+print("Connecting to AP...")
+while not esp.is_connected:
+    try:
+        esp.connect_AP(secrets["ssid"], secrets["password"])
+    except RuntimeError as e:
+        print("could not connect to AP, retrying: ", e)
+        continue
+print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
+print("My IP address is", esp.pretty_ip(esp.ip_address))
+print(
+    "IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com"))
+)
+print("Ping google.com: %d ms" % esp.ping("google.com"))
+
+# esp._debug = True
+print("Fetching text from", TEXT_URL)
+r = requests.get(TEXT_URL)
+print("-" * 40)
+print(r.text)
+print("-" * 40)
+r.close()
+
+print()
+print("Fetching json from", JSON_URL)
+r = requests.get(JSON_URL)
+print("-" * 40)
+print(r.json())
+print("-" * 40)
+r.close()
+print("Done!")

--- a/examples/pyportal_qrcode_generation.py
+++ b/examples/pyportal_qrcode_generation.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 Jose David M.
+# SPDX-License-Identifier: MIT
+
+"""
+This example shows a web address QR in the display
+"""
+
+import board
+from adafruit_pyportal.graphics import Graphics
+
+# Set display to show
+display = board.DISPLAY
+
+# Background Information
+base = Graphics(default_bg=0x990099, debug=True)
+
+# WebPage to show in the QR
+webpage = "http://www.adafruit.com"
+
+# QR size Information
+qr_size = 9  # Pixels
+scale = 3
+
+# Create a barcode
+base.qrcode(
+    webpage,
+    qr_size=scale,
+    x=display.width // 2 - qr_size * scale,
+    y=display.height // 2 - qr_size * scale,
+)
+
+while True:
+    pass


### PR DESCRIPTION
## Changes

1.  Adding to examples to illustrate in a simple way: WIFI connection and JSON data fetching, QR code generation
2. adding the learning guide in the library API
3. including examples in API `examples.rst`

intends to solve #89 

Examples were tested on 
```python
Adafruit CircuitPython 6.2.0-beta.4 on 2021-03-18; Adafruit PyPortal Titano with samd51j20
```