### PR TITLE
forced content type

### DIFF
--- a/adafruit_pyportal/__init__.py
+++ b/adafruit_pyportal/__init__.py
@@ -295,7 +295,7 @@ class PyPortal(PortalBase):
         )
         self.set_text(caption_text, index)
 
-    def fetch(self, refresh_url=None, timeout=10):
+    def fetch(self, refresh_url=None, timeout=10, force_content_type=None):
         """Fetch data from the url we initialized with, perfom any parsing,
         and display text or graphics. This function does pretty much everything
         Optionally update the URL
@@ -307,7 +307,10 @@ class PyPortal(PortalBase):
         response = self.network.fetch(self.url, headers=self._headers, timeout=timeout)
 
         json_out = None
-        content_type = self.network.check_response(response)
+        if not force_content_type:
+            content_type = self.network.check_response(response)
+        else:
+            content_type = force_content_type
         json_path = self._json_path
 
         if content_type == CONTENT_JSON:


### PR DESCRIPTION
resolves: https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/issues/57

Add a `force_content_type` argument that can be used to ignore the content_type returned from the server and treat it as the type specified.

Tested successfully with PyPortal discord learn guide project.