### PR TITLE
handle no .auto-brightness

### DIFF
--- a/adafruit_pyportal/peripherals.py
+++ b/adafruit_pyportal/peripherals.py
@@ -138,7 +138,10 @@ class Peripherals:
         if self._backlight:
             self._backlight.duty_cycle = int(val * 65535)
         else:
-            self._display.auto_brightness = False
+            try:
+                self._display.auto_brightness = False
+            except AttributeError:
+                pass
             self._display.brightness = val
 
     def play_file(self, file_name, wait_to_finish=True):


### PR DESCRIPTION
CircuitPython 8 builds have dropped support for `Display.auto_brightness` (https://github.com/adafruit/circuitpython/pull/6734). These changes handle the attribute no longer being available in 8.x.x, while still working on 7.x.x.

See https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/2239 for a more detailed explanation.