### PR TITLE
Update secrets usage

### DIFF
--- a/adafruit_pyportal/network.py
+++ b/adafruit_pyportal/network.py
@@ -119,8 +119,8 @@ class Network(NetworkBase):
         with the given width and height. aio_username and aio_key must be
         set in secrets."""
         try:
-            aio_username = self._secrets["aio_username"]
-            aio_key = self._secrets["aio_key"]
+            aio_username = self._get_setting("AIO_USERNAME")
+            aio_key = self._get_setting("AIO_KEY")
         except KeyError as error:
             raise KeyError(
                 "\n\nOur image converter service require a login/password to rate-limit. Please register for a free adafruit.io account and place the user/key in your secrets file under 'aio_username' and 'aio_key'"  # pylint: disable=line-too-long


### PR DESCRIPTION
I was updating various libraries on my device while testing the cleveland art project and noticed this function had reference to old version of the secrets values, it causes an exception to be raised.