### PR TITLE
Remove secrets and more

### DIFF
--- a/adafruit_pyportal/__init__.py
+++ b/adafruit_pyportal/__init__.py
@@ -124,7 +124,6 @@ class PyPortal(PortalBase):
         esp=None,
         external_spi=None,
         debug=False,
-        secrets_data=None,
     ):
         graphics = Graphics(
             default_bg=default_bg,
@@ -161,7 +160,6 @@ class PyPortal(PortalBase):
             image_position=image_position,
             image_dim_json_path=image_dim_json_path,
             debug=debug,
-            secrets_data=secrets_data,
         )
 
         self.url = url

--- a/adafruit_pyportal/network.py
+++ b/adafruit_pyportal/network.py
@@ -83,7 +83,6 @@ class Network(NetworkBase):
         image_resize=None,
         image_position=None,
         image_dim_json_path=None,
-        secrets_data=None,
     ):
         if status_neopixel:
             status_led = neopixel.NeoPixel(status_neopixel, 1, brightness=0.2)
@@ -95,7 +94,6 @@ class Network(NetworkBase):
             wifi,
             extract_values=extract_values,
             debug=debug,
-            secrets_data=secrets_data,
         )
 
         self._convert_image = convert_image
@@ -113,16 +111,16 @@ class Network(NetworkBase):
 
     def image_converter_url(self, image_url, width, height, color_depth=16):
         """Generate a converted image url from the url passed in,
-        with the given width and height. aio_username and aio_key must be
-        set in secrets."""
+        with the given width and height. ADAFRUIT_AIO_USERNAME and
+        ADAFRUIT_AIO_KEY must be set in settings.toml."""
         try:
-            aio_username = self._get_setting("AIO_USERNAME")
-            aio_key = self._get_setting("AIO_KEY")
+            aio_username = self._get_setting("ADAFRUIT_AIO_USERNAME")
+            aio_key = self._get_setting("ADAFRUIT_AIO_KEY")
         except KeyError as error:
             raise KeyError(
                 "\n\nOur image converter service require a login/password to rate-limit. "
                 "Please register for a free adafruit.io account and place the user/key in "
-                "your secrets file under 'aio_username' and 'aio_key'"
+                "your settings.toml file under 'ADAFRUIT_AIO_USERNAME' and 'ADAFRUIT_AIO_KEY'"
             ) from error
 
         return IMAGE_CONVERTER_SERVICE % (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,6 @@ autodoc_mock_imports = [
     "audiocore",
     "microcontroller",
     "neopixel",
-    "secrets",
     "adafruit_sdcard",
     "storage",
     "sdcardio",

--- a/examples/pyportal_internet_json_fetching.py
+++ b/examples/pyportal_internet_json_fetching.py
@@ -7,6 +7,8 @@ Example to illustrate the device capability to get json data
 
 # NOTE: Make sure you've created your settings.toml file before running this example
 # https://learn.adafruit.com/adafruit-pyportal/create-your-settings-toml-file
+from os import getenv
+
 import adafruit_connection_manager
 import adafruit_requests
 import board
@@ -42,10 +44,10 @@ requests = adafruit_requests.Session(pool, ssl_context)
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")
 print("Firmware vers.", esp.firmware_version)
-print("MAC addr:", [hex(i) for i in esp.MAC_address])
+print("MAC addr:", ":".join("%02X" % byte for byte in esp.MAC_address))
 
 for ap in esp.scan_networks():
-    print("\t%s\t\tRSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
+    print("\t%-23s RSSI: %d" % (ap.ssid, ap.rssi))
 
 print("Connecting to AP...")
 while not esp.is_connected:
@@ -54,8 +56,8 @@ while not esp.is_connected:
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
-print("My IP address is", esp.pretty_ip(esp.ip_address))
+print("Connected to", esp.ap_info.ssid, "\tRSSI:", esp.ap_info.rssi)
+print("My IP address is", esp.ipv4_address)
 print("IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com")))
 print("Ping google.com: %d ms" % esp.ping("google.com"))
 

--- a/examples/pyportal_internet_json_fetching.py
+++ b/examples/pyportal_internet_json_fetching.py
@@ -5,25 +5,26 @@
 Example to illustrate the device capability to get json data
 """
 
-# NOTE: Make sure you've created your secrets.py file before running this example
-# https://learn.adafruit.com/adafruit-pyportal/internet-connect#whats-a-secrets-file-17-2
+# NOTE: Make sure you've created your settings.toml file before running this example
+# https://learn.adafruit.com/adafruit-pyportal/create-your-settings-toml-file
 import adafruit_connection_manager
 import adafruit_requests
 import board
 from adafruit_esp32spi import adafruit_esp32spi
 from digitalio import DigitalInOut
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get wifi details and more from a settings.toml file
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD,
+#                           ADAFRUIT_AIO_USERNAME, ADAFRUIT_AIO_KEY
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+aio_username = getenv("ADAFRUIT_AIO_USERNAME")
+aio_key = getenv("ADAFRUIT_AIO_KEY")
 
 print("ESP32 SPI webclient test")
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
-JSON_URL = "http://api.coindesk.com/v1/bpi/currentprice/USD.json"
+JSON_URL = "http://wifitest.adafruit.com/testwifi/sample.json"
 
 
 # ESP32 Pins:
@@ -49,7 +50,7 @@ for ap in esp.scan_networks():
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(secrets["ssid"], secrets["password"])
+        esp.connect_AP(ssid, password)
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue

--- a/examples/pyportal_internet_json_fetching.py
+++ b/examples/pyportal_internet_json_fetching.py
@@ -16,12 +16,9 @@ from adafruit_esp32spi import adafruit_esp32spi
 from digitalio import DigitalInOut
 
 # Get wifi details and more from a settings.toml file
-# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD,
-#                           ADAFRUIT_AIO_USERNAME, ADAFRUIT_AIO_KEY
+# tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD
 ssid = getenv("CIRCUITPY_WIFI_SSID")
 password = getenv("CIRCUITPY_WIFI_PASSWORD")
-aio_username = getenv("ADAFRUIT_AIO_USERNAME")
-aio_key = getenv("ADAFRUIT_AIO_KEY")
 
 print("ESP32 SPI webclient test")
 

--- a/examples/pyportal_simpletest.py
+++ b/examples/pyportal_simpletest.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-# NOTE: Make sure you've created your secrets.py file before running this example
-# https://learn.adafruit.com/adafruit-pyportal/internet-connect#whats-a-secrets-file-17-2
+# NOTE: Make sure you've created your settings.toml file before running this example
+# https://learn.adafruit.com/adafruit-pyportal/create-your-settings-toml-file
 import board
 from displayio import CIRCUITPYTHON_TERMINAL
 


### PR DESCRIPTION
Minor updates to remove secrets usage and update keys:
1. Remove `secrets_data` as it will be pulled from `PortalBase`
2. Update `secrets.py` comments to `settings.toml`
3. Update AIO keys from `AIO_*` to `ADAFRUIT_AIO_*`
4. Update learn links to point to correct page for settings.toml
5. Fix `JSON_URL`

Tested both edited examples on a PyPortal running 9.2.4