### PR TITLE
Update examples to use root_group instead of splash

### DIFF
--- a/adafruit_pyportal/__init__.py
+++ b/adafruit_pyportal/__init__.py
@@ -178,7 +178,7 @@ class PyPortal(PortalBase):
 
         # Convenience Shortcuts for compatibility
         self.peripherals = Peripherals(
-            spi, display=self.display, splash_group=self.splash, debug=debug
+            spi, display=self.display, display_group=self.root_group, debug=debug
         )
         self.set_backlight = self.peripherals.set_backlight
         self.sd_check = self.peripherals.sd_check

--- a/adafruit_pyportal/graphics.py
+++ b/adafruit_pyportal/graphics.py
@@ -67,7 +67,7 @@ class Graphics(GraphicsBase):
         """Clear any QR codes that are currently on the screen"""
 
         if self._qr_only:
-            self.display.root_group = self.splash
+            self.display.root_group = self.root_group
         else:
             try:
                 self._qr_group.pop()

--- a/adafruit_pyportal/peripherals.py
+++ b/adafruit_pyportal/peripherals.py
@@ -49,7 +49,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyPortal.git"
 class Peripherals:
     """Peripherals Helper Class for the PyPortal Library"""
 
-    def __init__(self, spi, display, splash_group, debug=False):  # noqa: PLR0912,PLR0913 Too many branches,Too many arguments in function definition
+    def __init__(self, spi, display, display_group, debug=False):  # noqa: PLR0912,PLR0913 Too many branches,Too many arguments in function definition
         # Speaker Enable
         self._speaker_enable = DigitalInOut(board.SPEAKER_ENABLE)
         self._speaker_enable.switch_to_output(False)
@@ -109,7 +109,7 @@ class Peripherals:
 
             if debug:
                 print("Init cursor")
-            self.mouse_cursor = Cursor(board.DISPLAY, display_group=splash_group, cursor_speed=8)
+            self.mouse_cursor = Cursor(board.DISPLAY, display_group=display_group, cursor_speed=8)
             self.mouse_cursor.hide()
             self.cursor = CursorManager(self.mouse_cursor)
         else:


### PR DESCRIPTION
This updates the examples to reflect changes in https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/pull/108.